### PR TITLE
Add `!include` tag

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ black
 flake8
 flake8-docstrings
 flake8-annotations
+isort
 pytest
 pytest-cov
 mkdocs

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="yoco",
-    version="1.1.1",
+    version="1.2.0",
     author="Leonard Bruns",
     author_email="roym899@gmail.com",
     description="Minimalistic YAML-based configuration system",
@@ -21,5 +21,5 @@ setuptools.setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research"
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )

--- a/tests/test_files/config_w_include.yaml
+++ b/tests/test_files/config_w_include.yaml
@@ -1,0 +1,5 @@
+as_value: !include test_1.yaml
+in_list:
+  - !include test_1.yaml
+  - !include test_2.yaml
+!include test_1.yaml: null

--- a/tests/test_files/config_w_include.yaml
+++ b/tests/test_files/config_w_include.yaml
@@ -2,4 +2,3 @@ as_value: !include test_1.yaml
 in_list:
   - !include test_1.yaml
   - !include test_2.yaml
-!include test_1.yaml: null

--- a/tests/test_files/config_w_include.yaml
+++ b/tests/test_files/config_w_include.yaml
@@ -3,5 +3,6 @@ in_list:
   - !include test_1.yaml
   - !include test_2.yaml
   - 5
+  - !include test_1.yaml test_2.yaml
 !include config_1.yaml: null
 test_param_1: 5  # overwriting the value from config_1.yaml

--- a/tests/test_files/config_w_include.yaml
+++ b/tests/test_files/config_w_include.yaml
@@ -2,3 +2,6 @@ as_value: !include test_1.yaml
 in_list:
   - !include test_1.yaml
   - !include test_2.yaml
+  - 5
+!include config_1.yaml: null
+test_param_1: 5  # overwriting the value from config_1.yaml

--- a/tests/test_yoco.py
+++ b/tests/test_yoco.py
@@ -121,7 +121,6 @@ def test_include() -> None:
     expected_dict = {
         "as_value": {"test": 1},
         "in_list": [{"test": 1}, {"test": 2}],
-        "test": 1,
     }
 
     assert loaded_dict == expected_dict

--- a/tests/test_yoco.py
+++ b/tests/test_yoco.py
@@ -120,7 +120,10 @@ def test_include() -> None:
 
     expected_dict = {
         "as_value": {"test": 1},
-        "in_list": [{"test": 1}, {"test": 2}],
+        "in_list": [{"test": 1}, {"test": 2}, 5],
+        "test_param_1": 5,
+        "test_param_2": "Test string",
+        "test_list": [1, 2, 3]
     }
 
     assert loaded_dict == expected_dict

--- a/tests/test_yoco.py
+++ b/tests/test_yoco.py
@@ -120,7 +120,7 @@ def test_include() -> None:
 
     expected_dict = {
         "as_value": {"test": 1},
-        "in_list": [{"test": 1}, {"test": 2}, 5],
+        "in_list": [{"test": 1}, {"test": 2}, 5, {"test": 2}],
         "test_param_1": 5,
         "test_param_2": "Test string",
         "test_list": [1, 2, 3]

--- a/tests/test_yoco.py
+++ b/tests/test_yoco.py
@@ -1,8 +1,10 @@
 """Test functions for YOCO."""
+
 import argparse
 import copy
-import pytest
 import os
+
+import pytest
 
 import yoco
 
@@ -110,6 +112,19 @@ def test_save_config(tmp_path: str) -> None:
     yoco.save_config_to_file(file_path, original_dict)
     new_dict = yoco.load_config_from_file(file_path)
     assert original_dict == new_dict
+
+
+def test_include() -> None:
+    """Test loading a config file with various !include tags."""
+    loaded_dict = yoco.load_config_from_file("tests/test_files/config_w_include.yaml")
+
+    expected_dict = {
+        "as_value": {"test": 1},
+        "in_list": [{"test": 1}, {"test": 2}],
+        "test": 1,
+    }
+
+    assert loaded_dict == expected_dict
 
 
 def test_nested_config() -> None:
@@ -354,6 +369,7 @@ def test_config_from_parser() -> None:
 
 def test_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test resolving of paths with searchpaths and homefolder."""
+
     # expand home dir
     def mock_expanduser(path: str) -> str:
         return path.replace("~", "tests/home_dir")

--- a/yoco.py
+++ b/yoco.py
@@ -4,12 +4,14 @@ YOCO is based on Python dictionaries and YAML files to provide a simple, yet pow
 way of configuring Python projects. YOCO supports specifying parameters through the
 command line, YAML-files or directly from a Python dictionary.
 """
+
 import argparse as _argparse
 import copy
 import os as _os
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ruamel.yaml import YAML as _YAML
+from ruamel.yaml import comments as _YAMLComments
 
 _yaml = _YAML()
 
@@ -170,6 +172,7 @@ def load_config(
     else:
         current_dict = copy.deepcopy(current_dict)
 
+    # 1. handle config key if present
     if "config" in config_dict:
         current_dict = _resolve_config_key(
             config_dict, current_dict, parent, search_paths
@@ -177,9 +180,14 @@ def load_config(
 
     config_dict.pop("config", None)
 
+    # 2. handle !include tag
+    config_dict = _resolve_include_tags_recursively(config_dict, parent, search_paths)
+
+    # 3. resolve automatically recognized paths (./, ../, ~)
     if parent is not None:
         _resolve_paths_recursively(config_dict, parent)
 
+    # 4. merge config_dict into current_dict
     current_dict = _merge_dictionaries(current_dict, config_dict)
 
     return current_dict
@@ -273,7 +281,7 @@ def _resolve_config_key(
 
 def _resolve_config_dict(
     config_dict: list, current_dict: dict, parent: str, search_paths: List[str]
-) -> None:
+) -> dict:
     for ns, element in config_dict.items():
         if ns not in current_dict:
             current_dict[ns] = {}
@@ -294,7 +302,7 @@ def _resolve_config_dict(
 
 def _resolve_config_list(
     config_list: list, current_dict: dict, parent: str, search_paths: List[str]
-) -> None:
+) -> dict:
     for element in config_list:
         if isinstance(element, str):
             current_dict = load_config_from_file(
@@ -336,6 +344,41 @@ def _merge_dictionaries(start_dict: dict, added_dict: dict) -> dict:
         else:
             merged_dictionary[key] = value
     return merged_dictionary
+
+
+def _resolve_include_tags_recursively(
+    config: Any, parent: str, search_paths: Optional[List[str]]
+) -> Any:
+    """Handle !include tags in config_dict.
+
+    If a value has an !include tag it will be replaced by the content of the file.
+    If a key has an !include tag, the configuration will be merged into the current
+    dict.
+
+    Args:
+        config_dict: Configuration dictionary will not be modified.
+        parent: Parent directory.
+        search_paths: Search paths used to resolve config files.
+    Returns:
+        Clone of the configuration dictionary with resolved !include tags.
+    """
+    config = copy.deepcopy(config)
+    if isinstance(config, dict):
+        for key, value in config.items():
+            config[key] = _resolve_include_tags_recursively(
+                value, parent, search_paths=search_paths
+            )
+    elif isinstance(config, list):
+        for i in range(len(config)):
+            config[i] = _resolve_include_tags_recursively(
+                config[i], parent, search_paths=search_paths
+            )
+    elif isinstance(config, _YAMLComments.TaggedScalar) and config.tag == "!include":
+        return load_config_from_file(
+            config.value, parent=parent, search_paths=search_paths
+        )
+
+    return config
 
 
 def _resolve_paths_recursively(config_dict: dict, parent: str) -> None:


### PR DESCRIPTION
Add handling for `!include` tags.

An include tag has to be followed by one or more yaml files. E.g.
```
some_key: !include a_file.yaml another_file.yaml
```

These files are resolved in order as if they were specified by `--config a_file.yaml another_file.yaml`. The resulting configuration will be placed as the value to `some_key`.

Include tags can also appear as elements of a list behaving the same way (i.e., the resolved configuration will be become elements in the list).

Finally, include tags are also supported in dictionary keys. E.g.
```
!include a_file.yaml another_file.yaml:
some_key: 5
```
The value of an include-tagged key will be ignored (recommended to leave empty as above, which will result in `None`).
Instead, the configuration will be parsed as before and merged with the remaining configuration. Values existing in the including file will overwrite values in the included files. E.g., `some_key: 5` will take precedence over other `some_key: ...` entries in the included files.

Closes #4 